### PR TITLE
Enable tests in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+os: linux
+
+language: node_js
+
+node_js:
+  - "10"
+
+cache: npm
+
+services:
+  - docker
+
+before_script: npm run start:memcached
+
+script: npm run test:e2e

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   memcached:
     image: memcached:1.5.21
     container_name: memcached
+    command: memcached -vv
     ports:
       - 11211:11211
 


### PR DESCRIPTION
End-to-end tests will be run in Travis. Once unit or integration tests are added to the test suite, those will also be running in the CI too.

Resolves #9.