### PR TITLE
Enable authenticating cache routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # memproxyjs
+
 microservice wrapper for memcached
 
 ## Installation
 
-```
-$ npm i
+```sh
+npm i
 ```
 
 ## API Summary
@@ -18,9 +19,10 @@ Output payload:
 application/octet-stream containing cache entry.
 
 HTTP status codes:
-* 200, upon success
-* 404, if not present or expired
-* 5xx, upon server error
+
+- 200, upon success
+- 404, if not present or expired
+- 5xx, upon server error
 
 ### **Put Item**: PUT /cache/item
 
@@ -32,15 +34,22 @@ Input payload:
 application/octet-stream payload to be stored as the cached value.
 
 Output:
-application/json payload { "result": true } indicating success.
+application/json payload `{ "result": true }` indicating success.
 
 HTTP status codes:
-* 200, upon success
-* 5xx, upon server error
+
+- 200, upon success
+- 5xx, upon server error
 
 ### Administration
-* **Identity**: GET /
-* **Cache stats and health check**: GET /stats
+
+- **Identity**: GET /
+- **Cache stats and health check**: GET /stats
+
+## Authentication
+
+The routes at `/cache` can be set to require basic authentication.
+See [Configuration](#configuration) below.
 
 ## Configuration
 
@@ -48,12 +57,14 @@ Examines `PORT` environment variable for microservice listen port,
 or uses the express app default: 3000.
 
 Examines `UPSTREAM` environment variable for upstream memcached
-server location.  Multiple upstream servers are not supported.
+server location. Multiple upstream servers are not supported.
 Default, if not supplied: 127.0.0.1:11211
+
+Examines `AUTH_USER` and `AUTH_PASSWORD` environment variables for enabling authentication on the cache routes when both are set.
 
 ## Running
 
-```
+```sh
 npm start
 ```
 

--- a/app.js
+++ b/app.js
@@ -3,18 +3,32 @@
 const express = require('express')
 const logger = require('morgan')
 const Memcached = require('memcached')
+const debug = require('debug')('memcache-proxy:app')
+const basicAuth = require('express-basic-auth')
 
 const indexRouter = require('./routes/index')
 const cacheRouter = require('./routes/cache')
 
 const app = express()
 
-const upstream = process.env.UPSTREAM || '127.0.0.1:11211'
-app.locals.memcached = new Memcached(upstream)
+const { AUTH_USER, AUTH_PASS, UPSTREAM = '127.0.0.1:11211' } = process.env
+
+debug('Connecting to memcached at %s', UPSTREAM)
+app.locals.memcached = new Memcached(UPSTREAM)
 
 app.use(logger('dev'))
 
 app.use('/', indexRouter)
+
+if (AUTH_USER && AUTH_PASS) {
+  const auth = basicAuth({
+    unauthorizedResponse: 'Unauthorized',
+    users: { [AUTH_USER]: AUTH_PASS }
+  })
+  app.use('/cache', auth)
+  debug('Authentication enabled')
+}
+
 app.use('/cache', cacheRouter)
 
 module.exports = app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
   memproxy:
     build: .
     environment:
+      - AUTH_USER=${AUTH_USER}
+      - AUTH_PASS=${AUTH_PASS}
       - DEBUG=memcache*
       - PORT=${PORT:-3000}
       - UPSTREAM=${UPSTREAM:-memcached:11211}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1653,6 +1653,14 @@
         "vary": "~1.1.2"
       }
     },
+    "express-basic-auth": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.0.tgz",
+      "integrity": "sha512-iJ0h1Gk6fZRrFmO7tP9nIbxwNgCUJASfNj5fb0Hy15lGtbqqsxpt7609+wq+0XlByZjXmC/rslWQtnuSTVRIcg==",
+      "requires": {
+        "basic-auth": "^2.0.1"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "body-parser": "1.19.0",
     "debug": "2.6.9",
     "express": "4.17.1",
+    "express-basic-auth": "1.2.0",
     "memcached": "2.2.2",
     "morgan": "1.10.0",
     "request": "2.88.2",

--- a/test/e2e.spec.js
+++ b/test/e2e.spec.js
@@ -15,12 +15,14 @@ chai.use(chaiAsPromised).should()
 
 const request = rp.defaults({ json: true })
 
-describe('Memproxy end-to-end', function () {
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const baseUrl = `http://localhost:${process.env.PORT || 3000}`
+const { E2E, PORT = 3000, AUTH_USER, AUTH_PASS } = process.env
 
+const auth = AUTH_USER && AUTH_PASS ? `${AUTH_USER}:${AUTH_PASS}@` : ''
+const baseUrl = `http://${auth}localhost:${PORT || 3000}`
+
+describe('Memproxy end-to-end', function () {
   before(function () {
-    if (!process.env.E2E) {
+    if (!E2E) {
       this.skip()
     }
 


### PR DESCRIPTION
Resolves #19 by adding a basic authentication middleware if the proper environment variables are set.

This allows to easily enable authentication on the `/cache` routes to secure those without the need of any additional service/layer (i.e. NGINX) on top of `memproxyjs` to do so. 