### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "memcache-proxy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memcache-proxy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "docker build -t bloq/memproxyjs:${npm_package_version} .",


### PR DESCRIPTION
This will allow generating a new Docker image in DockerHub once merged and tagged.

Summary of changes since tag `v0.1.0`:

```
Gabriel Montes (10):
      Use node:alpine
      Run on non-root user "node" in the container
      Default to package.json to start the service
      Add health check to Dockerfile
      Add convenience script to build a Docker image
      Remove unused deps
      Update deps and fix versions
      Fix linting rules and errors
      Enable authenticating cache routes
      0.2.0

Martin Bon Foster (8):
      Adds ESLint, Prettier and TS rules
      Fixs all auto-fixable lint problems
      Solves linting errors
      Add husky and lint-staged
      Enables linting on the ci
      Separates lint-staged config in new file
      Splits ci test and lint scripts
      Changes eslint config
```

Resolve #25.