### PR TITLE
Support getting and setting multiple items in batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ HTTP status codes:
 - 404, if not present or expired
 - 5xx, upon server error
 
+### **Get Multiple Items**: POST /cache/getitems
+
+Input payload:
+application/json array of keys that need to be fetched
+
+Output payload:
+application/json object containing all the key values found with format `{ "key1": "value1", "key2": "value2" ...}`
+
+HTTP status codes:
+
+- 200, upon success
+- 5xx, upon server error
+
 ### **Put Item**: PUT /cache/item
 
 Input headers:
@@ -32,6 +45,19 @@ Input headers:
 
 Input payload:
 application/octet-stream payload to be stored as the cached value.
+
+Output:
+application/json payload `{ "result": true }` indicating success.
+
+HTTP status codes:
+
+- 200, upon success
+- 5xx, upon server error
+
+### **Put Multiple Items**: PUT /cache/items
+
+Input payload:
+application/json array of objects with format `{ "key": string, "value": string, "exp": number}`, each of them representing a value `value` that will be set with key `key` and expiration lifetime in seconds of `exp`.
 
 Output:
 application/json payload `{ "result": true }` indicating success.


### PR DESCRIPTION
Note: For supporting large batch GET/SET requests, I decided to:
* increase the maximum request body size to 50 mb
* not use a GET method with all the requested keys in the `X-MC-Key` header for multi get, because the max http header size is quickly reached. Since GET requests can not have a body payload, I defined a POST `/cache/getitems` endpoint, to avoid confusion with PUT `/cache/items`. Let me know if you prefer other naming convention.